### PR TITLE
feat(send-mri): add Gmail handler

### DIFF
--- a/prisma/migrations/20250814055944_no_need_for_model_to_hold_mri_subscribers/migration.sql
+++ b/prisma/migrations/20250814055944_no_need_for_model_to_hold_mri_subscribers/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `MriReceiver` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "MriReceiver" DROP CONSTRAINT "MriReceiver_assigneeId_fkey";
+
+-- AlterTable
+ALTER TABLE "Assignee" ADD COLUMN     "susbscribedMri" BOOLEAN NOT NULL DEFAULT false;
+
+-- DropTable
+DROP TABLE "MriReceiver";

--- a/prisma/migrations/20250814073535_fix_typo/migration.sql
+++ b/prisma/migrations/20250814073535_fix_typo/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `susbscribedMri` on the `Assignee` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Assignee" DROP COLUMN "susbscribedMri",
+ADD COLUMN     "mriSubscriber" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/models/mri.prisma
+++ b/prisma/models/mri.prisma
@@ -56,7 +56,7 @@ model Assignee {
     person          Person          @relation(fields: [peopleId], references: [id], onDelete: Cascade)
     peopleId        String          @unique
     assignedStudies StudyAssignee[]
-    mriReceiver     MriReceiver?
+    mriSubscriber   Boolean         @default(false)
 }
 
 /// Personal information of an assignee
@@ -183,9 +183,4 @@ model FormInterviews {
     cdpRequirements String
     /// Questions asked by the assignee during the interview
     questions       String
-}
-
-model MriReceiver {
-    assignee   Assignee @relation(fields: [assigneeId], references: [id])
-    assigneeId String   @id
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -18,7 +18,7 @@ async function seedFirstUser() {
             '\x1b[31m🌱  ADMIN_EMAIL not provided. Skipping first user seed.\x1b[0m'
         );
 
-    const position = process.env.ADMIN_POSITION ?? 'Info';
+    const position = process.env.ADMIN_POSITION ?? 'info';
 
     await db.admin.create({
         data: {

--- a/prisma/seed/assignees.ts
+++ b/prisma/seed/assignees.ts
@@ -35,9 +35,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 0,
                 },
             },
@@ -70,9 +68,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
             },
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 7,
                 },
             },
@@ -113,9 +109,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Donia.Franklin@hotmail.co.uk',
@@ -194,9 +188,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 2,
                 },
             },
@@ -236,9 +228,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 13,
                 },
             },
@@ -279,9 +269,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Dallas.Wells@seznam.cz',
@@ -303,9 +291,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 4,
                 },
             },
@@ -345,9 +331,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 9,
                 },
             },
@@ -409,9 +393,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Calder.Sampson@ntlworld.co.uk',
@@ -511,9 +493,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 6,
                 },
             },
@@ -554,9 +534,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 11,
                 },
             },
@@ -589,9 +567,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
             },
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 1,
                 },
             },
@@ -701,9 +677,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Alecia.Woods@charter.net',
@@ -743,9 +717,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 1,
                 },
             },
@@ -817,9 +789,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 11,
                 },
             },
@@ -1129,9 +1099,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             firstName: 'Griffin',
@@ -1263,9 +1231,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 5,
                 },
             },
@@ -1289,9 +1255,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 7,
                 },
             },
@@ -1345,9 +1309,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 12,
                 },
             },
@@ -1388,9 +1350,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -1414,9 +1374,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 12,
                 },
             },
@@ -1534,9 +1492,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -1569,9 +1525,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
             },
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 13,
                 },
             },
@@ -1595,9 +1549,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 2,
                 },
             },
@@ -1668,9 +1620,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
             },
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 6,
                 },
             },
@@ -1750,9 +1700,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 9,
                 },
             },
@@ -1793,9 +1741,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Kristin.Allison@aliceadsl.fr',
@@ -1873,9 +1819,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -1947,9 +1891,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 11,
                 },
             },
@@ -1981,9 +1923,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 10,
                 },
             },
@@ -2190,9 +2130,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
             },
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -2231,9 +2169,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 0,
                 },
             },
@@ -2305,9 +2241,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 6,
                 },
             },
@@ -2347,9 +2281,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -2390,9 +2322,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 6,
                 },
             },
@@ -2462,9 +2392,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 6,
                 },
             },
@@ -2504,9 +2432,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 2,
                 },
             },
@@ -2538,9 +2464,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             firstName: 'Elaina',
@@ -2570,9 +2494,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -2603,9 +2525,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 11,
                 },
             },
@@ -2677,9 +2597,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 10,
                 },
             },
@@ -2703,9 +2621,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 1,
                 },
             },
@@ -2746,9 +2662,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 3,
                 },
             },
@@ -2780,9 +2694,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
             },
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 12,
                 },
             },
@@ -2806,9 +2718,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 6,
                 },
             },
@@ -2831,9 +2741,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             firstName: 'Maurice',
@@ -2855,9 +2763,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 13,
                 },
             },
@@ -2898,9 +2804,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 1,
                 },
             },
@@ -2940,9 +2844,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'London.Simpson@tutanota.com',
@@ -3022,9 +2924,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 3,
                 },
             },
@@ -3085,9 +2985,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 5,
                 },
             },
@@ -3127,9 +3025,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 9,
                 },
             },
@@ -3152,9 +3048,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
         data: {
             assignee: {
                 create: {
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 2,
                 },
             },
@@ -3194,9 +3088,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 4,
                 },
             },
@@ -3236,9 +3128,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 8,
                 },
             },
@@ -3370,9 +3260,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 9,
                 },
             },
@@ -3412,9 +3300,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Jamie.Gomez@gmail.de',
@@ -3475,9 +3361,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                 },
             },
             email: 'Dexter.Hale@live.in',
@@ -3517,9 +3401,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: false,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 5,
                 },
             },
@@ -3598,9 +3480,7 @@ export async function seedAssigneesTestData(db: PrismaClient): Promise<string[]>
                             oldJet: true,
                         },
                     },
-                    mriReceiver: {
-                        create: {},
-                    },
+                    mriSubscriber: true,
                     nbApplications: 5,
                 },
             },

--- a/src/app/(public)/mri-mailing-list/subscribe/actions.ts
+++ b/src/app/(public)/mri-mailing-list/subscribe/actions.ts
@@ -15,7 +15,7 @@ async function findPerson({
             select: {
                 id: true,
                 email: true,
-                assignee: { select: { id: true, mriReceiver: true } },
+                assignee: { select: { id: true, mriSubscriber: true } },
             },
         });
         return person;
@@ -26,13 +26,10 @@ async function findPerson({
 
 async function subscribeNewPerson({ firstName, lastName, email }: MriSubscriptionType) {
     try {
-        return db.mriReceiver.create({
+        return db.assignee.create({
             data: {
-                assignee: {
-                    create: {
-                        person: { create: { email, lastName, firstName } },
-                    },
-                },
+                person: { create: { email, lastName, firstName } },
+                mriSubscriber: true,
             },
         });
     } catch (e) {
@@ -42,13 +39,10 @@ async function subscribeNewPerson({ firstName, lastName, email }: MriSubscriptio
 
 async function subscribeNewAssignee(id: string) {
     try {
-        return db.mriReceiver.create({
+        return db.assignee.create({
             data: {
-                assignee: {
-                    create: {
-                        person: { connect: { id } },
-                    },
-                },
+                person: { connect: { id } },
+                mriSubscriber: true,
             },
         });
     } catch (e) {
@@ -58,12 +52,9 @@ async function subscribeNewAssignee(id: string) {
 
 async function subscribeExisting(id: string) {
     try {
-        return db.mriReceiver.create({
-            data: {
-                assignee: {
-                    connect: { id },
-                },
-            },
+        return db.assignee.update({
+            where: { id },
+            data: { mriSubscriber: true },
         });
     } catch (e) {
         console.error(`[subscribeNewExisting] ${e}`);
@@ -120,7 +111,7 @@ export async function subscribePerson(
 
             personId = person.id;
             assigneeId = person.assignee?.id;
-            isMriReceiver = !!person.assignee?.mriReceiver?.assigneeId;
+            isMriReceiver = !!person.assignee?.mriSubscriber;
         } else {
             personId = previousPersonId;
             assigneeId = previousAssigneeId;

--- a/src/app/(public)/mri-mailing-list/subscribe/inner.tsx
+++ b/src/app/(public)/mri-mailing-list/subscribe/inner.tsx
@@ -36,7 +36,7 @@ export function Inner() {
             person?.id,
             person?.assignee?.id,
             changeEmail,
-            !!person?.assignee?.mriReceiver?.assigneeId
+            !!person?.assignee?.mriSubscriber
         ).then((data) => {
             setServerData(data);
             setLoading(false);

--- a/src/app/(public)/mri-mailing-list/subscribe/types.ts
+++ b/src/app/(public)/mri-mailing-list/subscribe/types.ts
@@ -1,7 +1,7 @@
 export interface FoundPerson {
     id: string;
     email: string | null;
-    assignee: { id: string; mriReceiver: { assigneeId: string } | null } | null;
+    assignee: { id: string; mriSubscriber: boolean } | null;
 }
 
 export type SubscribePersonReturn =

--- a/src/app/(user)/cdp/[study]/mri/form/schema.ts
+++ b/src/app/(user)/cdp/[study]/mri/form/schema.ts
@@ -3,7 +3,7 @@ import { Domain, Level, MriStatus } from '@prisma/client';
 import { z } from '@/lib/zod';
 
 export interface AdminDisplay {
-    email?: string;
+    email: string;
     firstName: string;
     lastName: string;
 }
@@ -18,7 +18,7 @@ export interface MriServerData {
 export function adminDisplay(cdp: {
     user: { person: { email: string | null; firstName: string; lastName: string } };
 }): AdminDisplay {
-    return { ...cdp.user.person, email: cdp.user.person.email ?? undefined };
+    return { ...cdp.user.person, email: cdp.user.person.email! };
 }
 
 export const mriCreationSchema = z

--- a/src/app/(user)/page.tsx
+++ b/src/app/(user)/page.tsx
@@ -1,5 +1,6 @@
 import FilesBrowser from '@/components/google/file-browser';
 import MailBrowser from '@/components/google/mail-browser';
+import { MailSender } from '@/components/google/mail-sender';
 
 async function HomePage() {
     return (
@@ -7,6 +8,7 @@ async function HomePage() {
             <div className="mb-4">Bienvenue sur le site de Telecom Etude</div>
             <FilesBrowser />
             <MailBrowser />
+            <MailSender />
         </div>
     );
 }

--- a/src/components/google/mail-sender.tsx
+++ b/src/components/google/mail-sender.tsx
@@ -2,20 +2,38 @@
 
 import { useState } from 'react';
 
-import { sendHelloWorld } from '@/google/mail/send';
+import { sendEmail } from '@/google/mail/send';
 
 import { Input } from '../ui/input';
 
 export function MailSender() {
     const [value, setValue] = useState('');
+    const [good, setGood] = useState<boolean | undefined>();
 
-    const sendEmail = () => {
-        if (value) sendHelloWorld(value);
+    const onBlur = () => {
+        if (value) {
+            setGood(undefined);
+            sendEmail({
+                to: value,
+                subject: 'Hello, World!',
+                html: '<p style="color: red">Hello world</p>"',
+                text: 'Hello world',
+                replyTo: 'info@telecom-etude.fr',
+            }).then((res) => setGood(res));
+        }
     };
 
     return (
         <Input
-            onBlur={() => sendEmail()}
+            onBlur={onBlur}
+            className={
+                'border-8 ' +
+                (good === true
+                    ? 'border-green-500'
+                    : good === false
+                      ? 'border-red-500'
+                      : 'border-blue-500')
+            }
             value={value}
             onChange={(e) => setValue(e.target.value)}
         />

--- a/src/components/google/mail-sender.tsx
+++ b/src/components/google/mail-sender.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+
+import { sendHelloWorld } from '@/google/mail/send';
+
+import { Input } from '../ui/input';
+
+export function MailSender() {
+    const [value, setValue] = useState('');
+
+    const sendEmail = () => {
+        if (value) sendHelloWorld(value);
+    };
+
+    return (
+        <Input
+            onBlur={() => sendEmail()}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+        />
+    );
+}

--- a/src/google/mail/send.ts
+++ b/src/google/mail/send.ts
@@ -1,0 +1,38 @@
+'use server';
+/**
+ * This file contains all the access to the Gmail API, with the send scope.
+ *
+ * This creates abstractions for the Gmail API in order to use Gmail accesses
+ * as server functions in an way that is agnostic of how the API actually works.
+ */
+
+import { auth } from '@/actions/auth';
+import { dbg } from '@/lib/utils';
+
+import { googleMail } from '../api';
+
+export async function sendHelloWorld(to: string): Promise<boolean> {
+    const gmail = await googleMail();
+    const session = await auth();
+    const from = session?.user.email;
+
+    const body = `From: ${from}
+To: ${to}
+Subject: Hi
+
+Hello, world!`;
+    const encodedBody = Buffer.from(body)
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '');
+
+    const sentEmail = await gmail.users.messages.send({
+        userId: 'me',
+        requestBody: { raw: encodedBody },
+    });
+
+    dbg(sentEmail, 'sentEmail');
+
+    return false;
+}

--- a/src/google/mail/send.ts
+++ b/src/google/mail/send.ts
@@ -1,4 +1,3 @@
-'use server';
 /**
  * This file contains all the access to the Gmail API, with the send scope.
  *
@@ -6,33 +5,89 @@
  * as server functions in an way that is agnostic of how the API actually works.
  */
 
+'use server';
+
 import { auth } from '@/actions/auth';
 import { dbg } from '@/lib/utils';
 
 import { googleMail } from '../api';
 
-export async function sendHelloWorld(to: string): Promise<boolean> {
-    const gmail = await googleMail();
-    const session = await auth();
-    const from = session?.user.email;
-
-    const body = `From: ${from}
-To: ${to}
-Subject: Hi
-
-Hello, world!`;
-    const encodedBody = Buffer.from(body)
+function base64UrlEncode(value: string): string {
+    return Buffer.from(value)
         .toString('base64')
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/=+$/g, '');
+}
 
-    const sentEmail = await gmail.users.messages.send({
-        userId: 'me',
-        requestBody: { raw: encodedBody },
-    });
+export interface EmailBuilder {
+    from?: string;
+    to: string;
+    subject: string;
+    cc?: string[];
+    bcc?: string[];
+    replyTo?: string;
+    text?: string;
+    html?: string;
+}
 
-    dbg(sentEmail, 'sentEmail');
+function rfc2822FromEmailBuilder(emailBuilder: EmailBuilder): string {
+    let rfc2822Message = '';
 
-    return false;
+    rfc2822Message += `From: ${emailBuilder.from}\r\n`;
+    rfc2822Message += `To: ${emailBuilder.to}\r\n`;
+    rfc2822Message += `Subject: ${emailBuilder.subject}\r\n`;
+
+    if (emailBuilder.cc && emailBuilder.cc.length >= 1)
+        rfc2822Message += `Cc: ${emailBuilder.cc.join(', ')}\r\n`;
+    if (emailBuilder.bcc && emailBuilder.bcc.length >= 1)
+        rfc2822Message += `Bcc: ${emailBuilder.bcc.join(', ')}\r\n`;
+
+    if (emailBuilder.replyTo) rfc2822Message += `Reply-To: ${emailBuilder.replyTo}\r\n`;
+
+    rfc2822Message += `Date: ${new Date().toUTCString()}\r\n`;
+    rfc2822Message += `MIME-Version: 1.0\r\n`;
+
+    const boundary = '--------------------';
+
+    rfc2822Message += `Content-Type: multipart/alternative; boundary="${boundary}"\r\n\r\n`;
+
+    if (emailBuilder.text) {
+        rfc2822Message += `--${boundary}\r\n`;
+        rfc2822Message += `Content-Type: text/plain; charset=UTF-8\r\n\r\n`;
+        rfc2822Message += `${emailBuilder.text}\r\n\r\n`;
+    }
+
+    if (emailBuilder.html) {
+        rfc2822Message += `--${boundary}\r\n`;
+        rfc2822Message += `Content-Type: text/html; charset=UTF-8\r\n\r\n`;
+        rfc2822Message += `${emailBuilder.html}\r\n\r\n`;
+    }
+
+    rfc2822Message += `--${boundary}--`;
+
+    return dbg(rfc2822Message, 'msg');
+}
+
+export async function sendEmail(emailBuilder: EmailBuilder): Promise<boolean> {
+    try {
+        console.log('sending');
+        const gmail = await googleMail();
+        const session = await auth();
+
+        if (!emailBuilder.from) emailBuilder.from = session?.user.email ?? undefined;
+
+        const raw = base64UrlEncode(rfc2822FromEmailBuilder(emailBuilder));
+
+        await gmail.users.messages.send({
+            userId: 'me',
+            requestBody: { raw },
+        });
+
+        return true;
+    } catch (e) {
+        console.error(`[sendEmail] ${e}`);
+
+        return false;
+    }
 }

--- a/src/google/mail/send.ts
+++ b/src/google/mail/send.ts
@@ -20,7 +20,7 @@ function base64UrlEncode(value: string): string {
         .replace(/=+$/g, '');
 }
 
-export interface EmailBuilder {
+interface EmailBuilder {
     from?: string;
     to: string;
     subject: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -73,10 +73,55 @@ export function reloadWindow() {
     if (typeof window != 'undefined') location.reload();
 }
 
+/**
+ * Returns a string with the full name of person
+ */
 export function personName({ firstName, lastName }: { firstName: string; lastName: string }) {
     return firstName + ' ' + lastName;
 }
 
+/**
+ * Returns a string with the full name of person and the email address between parentheses.
+ */
+export function personNameEmail({
+    email,
+    ...name
+}: {
+    firstName: string;
+    lastName: string;
+    email: string;
+}): string {
+    return `${personName(name)} (${email})`;
+}
+
+/**
+ * Returns a string with the full name and email address
+ * of every person of the given list of people
+ */
+export function peopleNameEmail(
+    people: { firstName: string; lastName: string; email: string }[]
+): string {
+    const len = people.length;
+    if (len === 0) return personNameEmail(people[0]);
+
+    let display = '';
+    for (let i = 0; i < len; ++i) {
+        display += `${personNameEmail(people[i])}`;
+        if (i === len - 1) {
+            break;
+        } else if (i === len - 2) {
+            display += ' et ';
+        } else {
+            display += ', ';
+        }
+    }
+
+    return display;
+}
+
+/**
+ * Returns a string with the full address, from an address database instance.
+ */
 export function stringifyAddress(address: Address): string {
     return (
         address.streetNumber +
@@ -89,4 +134,18 @@ export function stringifyAddress(address: Address): string {
         ', ' +
         address.country
     );
+}
+
+/**
+ * Escape HTML in user input, that shouldn't contain HTML.
+ *
+ * This function must be used on user input that is put in a dangerouslySetInnerHTML.
+ */
+export function sanitiseHtml(value: string) {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }


### PR DESCRIPTION
- **fix(schema): no need for model to hold mri subscribers**
- **fix(seed): default Info positions was renamed info**
- **feat(gmail): server action to send emails**
- **feat(gmail): add functionalities for email sender**
- **feat(lib): add functions to display people with emails**
- **fix(prisma): deletion of mriReceiver caused errors on mri/subscribe**
- **fix(mri): schema can assume admin email exists**

## Description

Adds basic Gmail functionality to send emails easily, in plain text and html through Jet-Centre.

This only works for sending emails with your email for the moment.

## Related Issue(s)

Related to #120, #33.

Closes #121.
